### PR TITLE
11 expandir rota de pedidos para aceitar POST, PUT e DELETE

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -70,6 +70,29 @@ def relatorio_pedidos_por_cliente(db: Session) -> list[schemas.RelatorioPedidosC
     ]
 
 
+def atualizar_pedido(
+    db: Session, pedido_id: int, pedido: schemas.PedidoUpdate
+) -> models.Pedido | None:
+    """Atualiza os dados de um pedido existente."""
+    db_pedido = db.query(models.Pedido).filter(models.Pedido.id == pedido_id).first()
+    if db_pedido:
+        for key, value in pedido.model_dump().items():
+            setattr(db_pedido, key, value)
+        db.commit()
+        db.refresh(db_pedido)
+    return db_pedido
+
+
+def deletar_pedido(db: Session, pedido_id: int) -> bool:
+    """Remove um pedido do banco de dados."""
+    db_pedido = db.query(models.Pedido).filter(models.Pedido.id == pedido_id).first()
+    if db_pedido:
+        db.delete(db_pedido)
+        db.commit()
+        return True
+    return False
+
+
 # Produtos
 def criar_produto(db: Session, produto: schemas.ProdutoCreate) -> models.Produto:
     """Cria um novo produto no banco de dados."""

--- a/app/routers/pedidos.py
+++ b/app/routers/pedidos.py
@@ -69,3 +69,47 @@ def obter_pedido(pedido_id: int, db: Session = Depends(get_db)):
     if not pedido:
         raise HTTPException(status_code=404, detail="Pedido não encontrado")
     return pedido
+
+# ...código existente...
+
+@router.put("/{pedido_id}", response_model=schemas.Pedido)
+def atualizar_pedido(
+    pedido_id: int,
+    pedido: schemas.PedidoUpdate,
+    db: Session = Depends(get_db)
+):
+    """
+    Atualiza um pedido existente.
+
+    Args:
+        pedido_id (int): ID do pedido.
+        pedido (PedidoUpdate): Dados atualizados do pedido.
+        db (Session): Sessão do banco de dados.
+
+    Returns:
+        Pedido atualizado.
+    """
+    pedido_atualizado = crud.atualizar_pedido(db, pedido_id, pedido)
+    if not pedido_atualizado:
+        raise HTTPException(status_code=404, detail="Pedido não encontrado")
+    return pedido_atualizado
+
+@router.delete("/{pedido_id}", response_model=dict)
+def deletar_pedido(
+    pedido_id: int,
+    db: Session = Depends(get_db)
+):
+    """
+    Remove um pedido pelo ID.
+
+    Args:
+        pedido_id (int): ID do pedido.
+        db (Session): Sessão do banco de dados.
+
+    Returns:
+        Mensagem de sucesso.
+    """
+    sucesso = crud.deletar_pedido(db, pedido_id)
+    if not sucesso:
+        raise HTTPException(status_code=404, detail="Pedido não encontrado")
+    return {"mensagem": "Pedido removido com sucesso"}

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -15,7 +15,10 @@ class PedidoCreate(PedidoBase):
 
     pass
 
-
+class PedidoUpdate(BaseModel):
+    """Schema para atualização de pedidos."""
+    descricao: str
+    
 class Pedido(PedidoBase):
     """Schema de leitura de pedidos."""
 


### PR DESCRIPTION
feat: adicionar PUT e DELETE em /pedidos, PedidoUpdate schema e métodos CRUD

Este PR expande a rota de pedidos para suportar operações de atualização e remoção.

### Alterações principais
- Adicionado método **PUT** em `/pedidos/{id}` para atualização de pedidos existentes.
- Adicionado método **DELETE** em `/pedidos/{id}` para remoção de pedidos.
- Criado schema `PedidoUpdate` para validar os dados de atualização.
- Refatorados os métodos do controller para suportar operações completas de CRUD.

### Motivo
Essas alterações permitem gerenciar pedidos de forma completa (criação, leitura, atualização e exclusão), atendendo à necessidade de expandir a API para manipulação total dos dados de pedidos.
